### PR TITLE
Added missing Python packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ keyring==10.1
 keyrings.alt==1.3
 # papirus==1.0.0
 # https://github.com/PiSupply/PaPiRus
-# picamera==1.13
+picamera==1.13
 Pillow==6.1.0
 pyasn1==0.1.9
 pycrypto==2.6.1
@@ -22,4 +22,5 @@ SecretStorage==2.3.1
 six==1.12.0
 ssh-import-id==5.6
 urllib3==1.19.1
-# zbarlight==2.3
+zbarlight==2.3
+qrcode


### PR DESCRIPTION
I'm not sure why zbarlight and picamera were commented out in this file, but they were needed. Also the app.py complained about a missing qrcode package.