### PR TITLE
Add logging to Telegram

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,6 +162,14 @@ def coins_inserted():
         logger.info("Satoshi price updated")
 
     if config.PULSES == 2:
+        config.FIAT += 0.02
+        config.COINCOUNT += 1
+        config.SATS = utils.get_sats()
+        config.SATSFEE = utils.get_sats_with_fee()
+        config.SATS -= config.SATSFEE
+        logger.info("2 cents added")
+        display.update_amount_screen()
+    if config.PULSES == 3:
         config.FIAT += 0.05
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
@@ -169,15 +177,15 @@ def coins_inserted():
         config.SATS -= config.SATSFEE
         logger.info("5 cents added")
         display.update_amount_screen()
-    if config.PULSES == 3:
-        config.FIAT += 0.10
+    if config.PULSES == 4:
+        config.FIAT += 0.1
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
         config.SATSFEE = utils.get_sats_with_fee()
         config.SATS -= config.SATSFEE
         logger.info("10 cents added")
         display.update_amount_screen()
-    if config.PULSES == 4:
+    if config.PULSES == 5:
         config.FIAT += 0.2
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
@@ -185,7 +193,7 @@ def coins_inserted():
         config.SATS -= config.SATSFEE
         logger.info("20 cents added")
         display.update_amount_screen()
-    if config.PULSES == 5:
+    if config.PULSES == 6:
         config.FIAT += 0.5
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
@@ -193,21 +201,13 @@ def coins_inserted():
         config.SATS -= config.SATSFEE
         logger.info("50 cents added")
         display.update_amount_screen()
-    if config.PULSES == 6:
+    if config.PULSES == 7:
         config.FIAT += 1
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("1 eur added")
-        display.update_amount_screen()
-    if config.PULSES == 7:
-        config.FIAT += 2
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
         config.SATS = utils.get_sats()
         config.SATSFEE = utils.get_sats_with_fee()
-        logger.info("2 eur added")
+        logger.info("100 cents added")
         display.update_amount_screen()
     config.PULSES = 0
 

--- a/app.py
+++ b/app.py
@@ -162,14 +162,6 @@ def coins_inserted():
         logger.info("Satoshi price updated")
 
     if config.PULSES == 2:
-        config.FIAT += 0.02
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("2 cents added")
-        display.update_amount_screen()
-    if config.PULSES == 3:
         config.FIAT += 0.05
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
@@ -177,15 +169,15 @@ def coins_inserted():
         config.SATS -= config.SATSFEE
         logger.info("5 cents added")
         display.update_amount_screen()
-    if config.PULSES == 4:
-        config.FIAT += 0.1
+    if config.PULSES == 3:
+        config.FIAT += 0.10
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
         config.SATSFEE = utils.get_sats_with_fee()
         config.SATS -= config.SATSFEE
         logger.info("10 cents added")
         display.update_amount_screen()
-    if config.PULSES == 5:
+    if config.PULSES == 4:
         config.FIAT += 0.2
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
@@ -193,7 +185,7 @@ def coins_inserted():
         config.SATS -= config.SATSFEE
         logger.info("20 cents added")
         display.update_amount_screen()
-    if config.PULSES == 6:
+    if config.PULSES == 5:
         config.FIAT += 0.5
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
@@ -201,13 +193,21 @@ def coins_inserted():
         config.SATS -= config.SATSFEE
         logger.info("50 cents added")
         display.update_amount_screen()
-    if config.PULSES == 7:
+    if config.PULSES == 6:
         config.FIAT += 1
+        config.COINCOUNT += 1
+        config.SATS = utils.get_sats()
+        config.SATSFEE = utils.get_sats_with_fee()
+        config.SATS -= config.SATSFEE
+        logger.info("1 eur added")
+        display.update_amount_screen()
+    if config.PULSES == 7:
+        config.FIAT += 2
         config.COINCOUNT += 1
         config.SATS = utils.get_sats()
         config.SATS = utils.get_sats()
         config.SATSFEE = utils.get_sats_with_fee()
-        logger.info("100 cents added")
+        logger.info("2 eur added")
         display.update_amount_screen()
     config.PULSES = 0
 
@@ -316,11 +316,18 @@ def main():
 
     # Display startup startup_screen
     display.update_startup_screen()
+    lastupdate=time.time()
 
     setup_coin_acceptor()
 
     while True:
         monitor_coins_and_button()
+
+        # Update the homescreen (and thus the time) every 60s
+        if ( time.time() - lastupdate ) > 60:
+            display.update_startup_screen()
+            lastupdate=time.time()
+
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import config
 import lndrest
 import lntxbot
 import qr
+import telegram
 
 import utils
 import importlib
@@ -22,6 +23,12 @@ display = getattr(__import__("displays", fromlist=[display_config]), display_con
 led = "off"
 logger = logging.getLogger("MAIN")
 
+# Extend logging with Telegram if we got a bot_key
+if config.conf["telegram"]["bot_key"]:
+    telegram_handler=telegram.TelegramHandler()
+    telegram_handler.setLevel(logging.INFO)
+    logger.addHandler(telegram_handler)
+
 
 def softreset():
     """Displays startup screen and deletes fiat amount
@@ -30,7 +37,7 @@ def softreset():
     config.SATS = 0
     config.FIAT = 0
     if config.COINCOUNT > 0:
-        logger.info("%s Coin(s) and XX Bill(s) added", config.COINCOUNT)
+        logger.debug("%s Coin(s) and XX Bill(s) added", config.COINCOUNT)
     config.COINCOUNT = 0
     # Turn off button LED
     GPIO.output(13, GPIO.LOW)
@@ -159,7 +166,7 @@ def coins_inserted():
     if config.FIAT == 0:
         config.BTCPRICE = utils.get_btc_price(config.conf["atm"]["cur"])
         config.SATPRICE = math.floor((1 / (config.BTCPRICE * 100)) * 100000000)
-        logger.info("Satoshi price updated")
+        logger.debug("Satoshi price updated")
 
     if config.PULSES == 2:
         config.FIAT += 0.02
@@ -215,7 +222,7 @@ def coins_inserted():
         # Turn on the LED after first coin
         GPIO.output(13, GPIO.HIGH)
         led = "on"
-        logger.info("Button-LED turned on (if connected)")
+        logger.debug("Button-LED turned on (if connected)")
 
 
 def monitor_coins_and_button():
@@ -317,6 +324,7 @@ def main():
     # Display startup startup_screen
     display.update_startup_screen()
     lastupdate=time.time()
+
 
     setup_coin_acceptor()
 

--- a/displays/waveshare2in13.py
+++ b/displays/waveshare2in13.py
@@ -7,6 +7,7 @@ import config
 import utils
 
 from displays import messages
+import datetime
 
 from PIL import Image, ImageFont, ImageDraw
 
@@ -33,6 +34,14 @@ def update_startup_screen():
         messages.startup_screen_3,
         fill=config.BLACK,
         font=utils.create_font("freemono", 16),
+    )
+
+    # Time
+    draw.text(
+        (210, 0),
+        str(datetime.datetime.now().strftime("%H:%M")),
+        fill=config.BLACK,
+        font=utils.create_font("freemono", 14),
     )
 
     config.WAVESHARE.init(config.WAVESHARE.FULL_UPDATE)

--- a/displays/waveshare2in13.py
+++ b/displays/waveshare2in13.py
@@ -7,7 +7,6 @@ import config
 import utils
 
 from displays import messages
-import datetime
 
 from PIL import Image, ImageFont, ImageDraw
 
@@ -34,14 +33,6 @@ def update_startup_screen():
         messages.startup_screen_3,
         fill=config.BLACK,
         font=utils.create_font("freemono", 16),
-    )
-
-    # Time
-    draw.text(
-        (210, 0),
-        str(datetime.datetime.now().strftime("%H:%M")),
-        fill=config.BLACK,
-        font=utils.create_font("freemono", 14),
     )
 
     config.WAVESHARE.init(config.WAVESHARE.FULL_UPDATE)

--- a/example_config.ini
+++ b/example_config.ini
@@ -43,3 +43,10 @@ macaroon =
 # base64 encoded lntxbot api credentials
 url =
 creds =
+
+[telegram]
+# Create a bot using @botfather (/newbot). Give key below:
+bot_key = 
+# Your own user ID to send messages to ( @lightningwatchbot 
+# can give you this if you type /referral )
+user_id = 

--- a/telegram.py
+++ b/telegram.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import json
+import logging
+from urllib import request, parse
+
+import config
+import utils
+
+# import display
+display_config = config.conf["atm"]["display"]
+display = getattr(__import__("displays", fromlist=[display_config]), display_config)
+
+logger = logging.getLogger("LNTXBOT")
+
+class TelegramHandler(logging.StreamHandler):
+    """Allow for logging to Telegram
+    """
+    def emit(self,record):
+        
+        self.send_message(record.getMessage())
+
+    def send_message(self,message):
+        """Send a message over Telegram
+        """
+        logger.info("Sending message [{}]".format(message))
+
+        bot_key=config.conf["telegram"]["bot_key"] 
+        user_id=config.conf["telegram"]["user_id"] 
+
+        # Message object
+        data = { 
+            "chat_id": user_id,
+            "text": message,
+             }
+
+        data = json.dumps(data)
+        data = str(data)
+        data = data.encode('utf-8')
+
+        # Post Method is invoked if data != None
+        req =  request.Request(
+                "https://api.telegram.org/bot{bot_key}/sendMessage".format(bot_key=bot_key),
+                data=data,
+                headers={
+                    "Content-Type":"application/json",
+                    })
+
+        # Response
+        resp = request.urlopen(req)


### PR DESCRIPTION
1. Create a bot using https://t.me/botfather , enter the key in config
2. Figure out your own Telegram user ID, you can ask https://t.me/lightningwatchbot for a /referral , the code is your user ID, add to config
3. If app.py sees a bot key is set, it will add a handler to the existing logging module

It works well here. There are still a bit too many messages, so some are missed. We might have to lower some more message priorities to DEBUG to lower Telegram sending. Currently INFO and higher is sent.

```
[telegram]
# Create a bot using @botfather (/newbot). Give key below:
bot_key = 
# Your own user ID to send messages to ( @lightningwatchbot 
# can give you this if you type /referral )
user_id = 
```
