### PR TITLE
Allow for configuring pulses + fiat values in config file

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,87 +156,37 @@ def coins_inserted():
     """
     global led
 
+    # Check if we should update prices
     if config.FIAT == 0:
+        # Our counter is 0, meaning we got no fiat in:
         config.BTCPRICE = utils.get_btc_price(config.conf["atm"]["cur"])
-        config.SATPRICE = math.floor((1 / (config.BTCPRICE * 100)) * 100000000)
-        logger.info("Satoshi price updated")
+        config.SATPRICE = math.floor((1 / (config.BTCPRICE * 100)) * 1e8)
+        logger.debug("Satoshi price updated")
 
-    if config.PULSES == 2:
-        config.FIAT += 0.02
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("2 cents added")
-        display.update_amount_screen()
-    if config.PULSES == 3:
-        config.FIAT += 0.05
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("5 cents added")
-        display.update_amount_screen()
-    if config.PULSES == 4:
-        config.FIAT += 0.1
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("10 cents added")
-        display.update_amount_screen()
-    if config.PULSES == 5:
-        config.FIAT += 0.2
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("20 cents added")
-        display.update_amount_screen()
-    if config.PULSES == 6:
-        config.FIAT += 0.5
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        config.SATS -= config.SATSFEE
-        logger.info("50 cents added")
-        display.update_amount_screen()
-    if config.PULSES == 7:
-        config.FIAT += 1
-        config.COINCOUNT += 1
-        config.SATS = utils.get_sats()
-        config.SATS = utils.get_sats()
-        config.SATSFEE = utils.get_sats_with_fee()
-        logger.info("100 cents added")
-        display.update_amount_screen()
+    # We must have gotten pulses!
+    print(config.PULSES)
+    config.FIAT +=      float(config.COINTYPES[config.PULSES]['fiat'])
+    config.COINCOUNT += 1
+    config.SATS =       utils.get_sats()
+    config.SATSFEE =    utils.get_sats_with_fee()
+    config.SATS -=      config.SATSFEE
+    logger.info("Added {}".format(config.COINTYPES[config.PULSES]['name']))
+    display.update_amount_screen()
+
+    # Reset pulse cointer
     config.PULSES = 0
 
     if config.FIAT > 0 and led == "off":
         # Turn on the LED after first coin
         GPIO.output(13, GPIO.HIGH)
         led = "on"
-        logger.info("Button-LED turned on (if connected)")
+        logger.debug("Button-LED turned on (if connected)")
 
 
 def monitor_coins_and_button():
     """Monitors coins inserted and buttons pushed
     """
     time.sleep(0.2)
-
-    # Potentially new way of detecting coin insertions
-    # if config.COINLIST:
-    #     time.sleep(1)
-    #     if config.COINLIST.count("0") > 1:
-    #         print(config.COINLIST[1 : config.COINLIST.index("0", 1)])
-    #         print(len(config.COINLIST[1 : config.COINLIST.index("0", 1)]))
-    #     else:
-    #         print(config.COINLIST[1:])
-    #         print(len(config.COINLIST[1:]))
-    #         if len(config.COINLIST[1:]) > 0:
-    #             config.PULSLIST.append(len(config.COINLIST[1:]))
-    #             del config.COINLIST[: len(config.COINLIST[1:])]
-    #
-    # print(config.PULSLIST)
 
     # Detect when coins are being inserted
     if (time.time() - config.LASTIMPULSE > 0.5) and (config.PULSES > 0):

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 from configparser import ConfigParser
 import logging
 import os
+import sys
 import math
 from shutil import copyfile
 
@@ -138,7 +139,7 @@ INVOICE = ""
 
 # Set btc and sat price
 BTCPRICE = utils.get_btc_price(conf["atm"]["cur"])
-SATPRICE = math.floor((1 / (BTCPRICE * 100)) * 100000000)
+SATPRICE = math.floor((1 / (BTCPRICE * 100)) * 1e8)
 
 # Button / Acceptor Pulses
 LASTIMPULSE = 0
@@ -147,6 +148,13 @@ LASTPUSHES = 0
 PUSHES = 0
 COINCOUNT = 0
 
-# Lists for different coin counting, not yet implemented
-# COINLIST = []
-# PULSLIST = []
+# Determine different coin types
+COINTYPES={}
+try:
+    for coin_type in conf['coins']['coin_types'].split("\n"):
+        coin_type_pulses,coin_type_fiat,coin_type_name=coin_type.split(',')
+        COINTYPES[int(coin_type_pulses)]={'fiat': coin_type_fiat, 'name': coin_type_name}
+except:
+    print("Pulses not set in the new way, please update config")
+    sys.exit(2)
+

--- a/example_config.ini
+++ b/example_config.ini
@@ -43,3 +43,12 @@ macaroon =
 # base64 encoded lntxbot api credentials
 url =
 creds =
+
+[coins]
+# Pulsecount, fiat value, name
+coin_types = 2,0.05,5  eur cent
+             3,0.10,10 eur cent
+             4,0.20,20 eur cent
+             5,0.50,50 eur cent
+             6,1.00,1 eur
+             7,2.00,2 eur


### PR DESCRIPTION
This PR allows for setting coin types in the actual config file, as below:
```
[coins]
# Pulsecount, fiat value, name
coin_types = 2,0.05,5  eur cent
             3,0.10,10 eur cent
             4,0.20,20 eur cent
             5,0.50,50 eur cent
             6,1.00,1 eur
             7,2.00,2 eur
```