### PR TITLE
support newer/more versions of inky pHAT displays

### DIFF
--- a/config.py
+++ b/config.py
@@ -169,11 +169,11 @@ elif "waveshare2in7" in conf["atm"]["display"]:
 # Display - Inky pHAT
 elif "inkyphat" in conf["atm"]["display"]:
     try:
-        from inky import InkyPHAT
+        from inky.auto import auto
 
         WHITE = 0
         BLACK = 1
-        INKY = InkyPHAT("black")
+        INKY = auto(ask_user=True, verbose=True)
         INKY.set_border(INKY.WHITE)
     except ImportError:
         logger.warning("Inky display library not installed.")


### PR DESCRIPTION
By using the auto-detect feature of the inky library also newer versions of the popular inky pHAT display are supported (for example the "InkyPHAT_SSD1608" is supported without having to specify it specifically).

Tested it with a InkyPHAT_SSD1608 and it works fine so far. Only issue is as the resolution is a bit higher but the screens are drawn using absolute values (pixels), there is a bit of empty "border" on the very right and bottom of the display.
This might be corrected by calculating relative positions depending on the display resolution.

Note: as it is a friend of mine who build the ATM, I do not have access to the display that frequently.