### PR TITLE
fixed timeout when using lnbits.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ def button_pushed():
 
                     # draw the qr code on the e-ink screen
                     display.draw_lnurl_qr(qr_img)
-                    success = lnbits.wait_for_lnurlw_redemption(resp["id"], timeout=int(config.conf["lnbits"].get("timeout", 1000*90)))
+                    success = lnbits.wait_for_lnurlw_redemption(resp["id"], timeout=int(config.conf["lnbits"].get("timeout", 90)))
                     if success:
                         pass
                     else:

--- a/example_config.ini
+++ b/example_config.ini
@@ -75,8 +75,8 @@ url = https://legend.lnbits.com/api/v1
 apikey = 
 # One of "invoice" or "lnurlw"
 method = lnurlw
-# only for lnurlw - millisseconds to redeem the lnurlw
-timeout = 90000
+# only for lnurlw - seconds to redeem the lnurlw
+timeout = 90
 
 [coins]
 # Pulsecount, fiat value, name

--- a/lnbits.py
+++ b/lnbits.py
@@ -246,7 +246,7 @@ def create_lnurlw():
     else:
         return res_json
 
-def wait_for_lnurlw_redemption(id, timeout=1000 * 90):
+def wait_for_lnurlw_redemption(id, timeout=90):
     """ Waits until the lnurlw with the id (created by create_lnurlw) is used.
         timeouts after 90 seconds (default)
         returns True/False depending on success


### PR DESCRIPTION
The value for the timeout in the lnbits.py implementation needs to be in seconds and not in milliseconds.