### PR TITLE
added restart on service

### DIFF
--- a/LightningATM.service
+++ b/LightningATM.service
@@ -7,6 +7,9 @@ User=pi
 Type=idle
 WorkingDirectory=/home/pi/LightningATM
 ExecStart=/usr/bin/python3 /home/pi/LightningATM/app.py
+Restart=always
+TimeoutSec=60
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Improved service restart on startup when connecting to wifi.

When the pi starts and wifi is connected found but the service runs, it fails with an error and needs to be manually restarted.

The lines we add do exactly that, when failed, wait and restart the service.

Tested with @AxelHamburch on Telegram